### PR TITLE
Rule of 0

### DIFF
--- a/includes/wikigraph.hpp
+++ b/includes/wikigraph.hpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include <map>
 
+typedef std::map<std::string, std::vector<std::string>> Graph;
+
 class WikiGraph {
   public:
     struct RankedPage {
@@ -11,17 +13,14 @@ class WikiGraph {
       double rank = -1.0;
     };
 
-    WikiGraph();
     WikiGraph(const std::string& file_name); // construct from file
-    ~WikiGraph();
-    WikiGraph& operator=(WikiGraph& other); // could possibly have this as deleted.
 
     std::vector<std::string> getPathBFS(const std::string& from_page, const std::string& to_page) const;
     std::vector<std::string> getPathDijkstras(const std::string& from_page, const std::string& to_page) const;
     std::vector<RankedPage> rankPages() const;
-    std::map<std::string, std::vector<std::string>> getMap() { return article_map; } // for tests
+    Graph getMap() { return article_map; } // for tests
   private:
     std::vector<std::string> getAdjacentArticles(const std::string& from_page) const;
 
-    std::map<std::string, std::vector<std::string>> article_map;
+    Graph article_map;
 };

--- a/includes/wikigraph.hpp
+++ b/includes/wikigraph.hpp
@@ -13,6 +13,7 @@ class WikiGraph {
       double rank = -1.0;
     };
 
+    WikiGraph() = delete; // require that data be entered into the graph
     WikiGraph(const std::string& file_name); // construct from file
 
     std::vector<std::string> getPathBFS(const std::string& from_page, const std::string& to_page) const;

--- a/src/wikigraph.cc
+++ b/src/wikigraph.cc
@@ -3,12 +3,6 @@
 #include <unordered_map>
 #include <fstream>
 
-// ------- Rule of Threes ---------
-// TODO: Constructor
-WikiGraph::WikiGraph() {
-
-}
-
 // TODO: Construct from File
 WikiGraph::WikiGraph(const std::string& file_name) {
   // Reads in file stream.
@@ -39,18 +33,6 @@ WikiGraph::WikiGraph(const std::string& file_name) {
 
     article_map[src].push_back(dest);
   }
-}
-
-// TODO: Destructor
-WikiGraph::~WikiGraph() {
-
-}
-
-// TODO: Copy Assignment Operator
-WikiGraph& WikiGraph::operator=(WikiGraph& other) {
-  // ??
-  (void) other;
-  return *this;
 }
 
 


### PR DESCRIPTION
- It is pretty clear that our only data member will handle memory on its own, so we do not need a custom destructor, copy constructor, or assignment operator.
- I also defined `Graph` as a `std::map<std::string, std::vector<std::string>>` to make our interface a little easier to read. 
- Deleted the default constructor declaration, as it is also unnecessary