### PR TITLE
Adds keys for pages without outbound links

### DIFF
--- a/src/wikigraph.cc
+++ b/src/wikigraph.cc
@@ -38,6 +38,10 @@ WikiGraph::WikiGraph(const std::string& file_name) {
     auto dest = decoded[pages[1]];
 
     article_map[src].push_back(dest);
+    if (article_map.find(dest) == article_map.end()) {
+      // create a vertex for the destination (constructs an empty list)
+      article_map[dest];
+    }
   }
 }
 

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -15,9 +15,11 @@ TEST_CASE("Intake test", "constructor") {
   std::map<std::string, std::vector<std::string>> expected = 
   {
     {"A", {"B", "C"}},
+    {"B", {}},
     {"C", {"D"}},
+    {"D", {}},
     {"this has spaces", {"B"}},
-    {"\"article\"", {"D"}}
+    {"\"article\"", {"D"}},
   };
 
   WikiGraph w("./datasets/test.tsv");


### PR DESCRIPTION
Creates an empty adjacency list for the destination of each edge, so each page (even if it has no links out) is represented by a kv pair in the map.