### PR TITLE
Constructor now properly ignores whitespace at end of file

### DIFF
--- a/src/wikigraph.cc
+++ b/src/wikigraph.cc
@@ -19,7 +19,9 @@ WikiGraph::WikiGraph(const std::string& file_name) {
   std::string file = file_to_string(file_name);
   std::vector<std::string> lines;
   SplitString(file, '\n', lines);
-  lines.pop_back(); // our dataset has a line of empty space that we can discard
+  // our dataset has a line of empty space that we can discard
+  if (lines.back().empty())
+    lines.pop_back(); 
 
   std::unordered_map<std::string, std::string> decoded; // memoize decoding
   for (auto& line : lines) {


### PR DESCRIPTION
Pretty simple conditional, but it stops me from having to remember to put whitespace at the end of test files