### PR TITLE
Intake fix

### DIFF
--- a/datasets/cycle.tsv
+++ b/datasets/cycle.tsv
@@ -1,0 +1,6 @@
+A	B
+B	C
+C	A
+A	E
+D	E
+B	D

--- a/includes/wikigraph.hpp
+++ b/includes/wikigraph.hpp
@@ -16,15 +16,17 @@ public:
   WikiGraph() = delete;  // require that data be entered into the graph
   WikiGraph(const std::string& file_name);  // construct from file
 
-  std::vector<std::string> getPathBFS(const std::string& from_page,
-                                      const std::string& to_page) const;
-  std::vector<std::string> getPathDijkstras(const std::string& from_page,
-                                            const std::string& to_page) const;
+  std::vector<std::string> getPathBFS(const std::string&,
+                                      const std::string&) const;
+  std::vector<std::string> getPathDijkstras(const std::string&,
+                                            const std::string&) const;
   std::vector<RankedPage> rankPages() const;
   Graph getMap() { return article_map; }  // for tests
 private:
   std::vector<std::string> getAdjacentArticles(
-      const std::string& from_page) const;
+      const std::string&) const;
+
+  bool validStartAndEnd(const std::string&, const std::string&) const;
 
   Graph article_map;
 };

--- a/includes/wikigraph.hpp
+++ b/includes/wikigraph.hpp
@@ -21,7 +21,8 @@ public:
   std::vector<std::string> getPathDijkstras(const std::string&,
                                             const std::string&) const;
   std::vector<RankedPage> rankPages() const;
-  Graph getMap() { return article_map; }  // for tests
+  Graph getMap() const { return article_map; }  // for tests
+  std::vector<std::string> getPages() const;
 private:
   std::vector<std::string> getAdjacentArticles(
       const std::string&) const;

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -16,7 +16,7 @@ std::string DecodeURL(const std::string& url_str) {
       out << (char)(std::stoi(url_str.substr(i+1, 2), nullptr, 16));
       i += 2; // skip the next two characters
     } else if (url_str[i] == '_') { // handle space
-      out << " ";
+      out << (url_str[i+1] == '_' ? ": " : " ");
     } else {
       out << url_str[i];
     }

--- a/src/wikigraph.cc
+++ b/src/wikigraph.cc
@@ -2,7 +2,6 @@
 
 #include <fstream>
 #include <queue>
-#include <unordered_map>
 
 #include "utilities.hpp"
 
@@ -20,7 +19,7 @@ WikiGraph::WikiGraph(const std::string& file_name) {
   if (lines.back().empty())
     lines.pop_back(); 
 
-  std::unordered_map<std::string, std::string> decoded; // memoize decoding
+  std::map<std::string, std::string> decoded; // memoize decoding
   for (auto& line : lines) {
     std::vector<std::string> pages;
     SplitString(line, '\t', pages);
@@ -107,12 +106,7 @@ std::vector<std::string> WikiGraph::getPathDijkstras(const std::string& start_pa
     throw std::invalid_argument("One or more of these pages are not in the graph");
   }
 
-  // extract keys from map
-  std::vector<std::string> pages;
-  std::transform(article_map.begin(), article_map.end(), std::back_inserter(pages),
-      [](decltype(article_map)::value_type const &kv) {
-          return kv.first;
-      });
+  auto pages = getPages();
 
  // init distance and predecessor
  std::map<std::string, int> distance;
@@ -155,7 +149,7 @@ std::vector<std::string> WikiGraph::getPathDijkstras(const std::string& start_pa
 
   // there is no path from the start to the end
   if (std::find(path.begin(), path.end(), start_page) == path.end()) {
-    throw std::invalid_argument("There is no path between these articles");
+    throw std::runtime_error("There is no path between these articles");
   }
   
   // return the reversed version (start -> end)
@@ -171,4 +165,15 @@ std::vector<WikiGraph::RankedPage> WikiGraph::rankPages() const {
 
 bool WikiGraph::validStartAndEnd(const std::string& start_page, const std::string& end_page) const {
   return (article_map.find(start_page) != article_map.end()) && (article_map.find(end_page) != article_map.end());
+}
+
+std::vector<std::string> WikiGraph::getPages() const {
+  // extract keys from map
+  std::vector<std::string> pages;
+  std::transform(article_map.begin(), article_map.end(), std::back_inserter(pages),
+      [](decltype(article_map)::value_type const &kv) {
+          return kv.first;
+      });
+
+  return pages;
 }

--- a/src/wikigraph.cc
+++ b/src/wikigraph.cc
@@ -49,6 +49,10 @@ WikiGraph::WikiGraph(const std::string& file_name) {
 std::vector<std::string> WikiGraph::getPathBFS(
     const std::string& start_page, const std::string& end_page) const {
 
+  if (!validStartAndEnd(start_page, end_page)) {
+    throw std::invalid_argument("These pages are not in the graph");
+  }
+
   std::vector<std::string> page_path;
 
   std::map<std::string, std::string> page_tree;
@@ -98,12 +102,17 @@ std::vector<std::string> WikiGraph::getPathBFS(
 // TODO: getPathDijkstras()
 std::vector<std::string> WikiGraph::getPathDijkstras(const std::string& start_page, const std::string& end_page) const {
 
-// extract keys from map
-std::vector<std::string> pages;
-std::transform(article_map.begin(), article_map.end(), std::back_inserter(pages),
-    [](decltype(article_map)::value_type const &kv) {
-        return kv.first;
-    });
+  // require start and end exist
+  if (!validStartAndEnd(start_page, end_page)) {
+    throw std::invalid_argument("One or more of these pages are not in the graph");
+  }
+
+  // extract keys from map
+  std::vector<std::string> pages;
+  std::transform(article_map.begin(), article_map.end(), std::back_inserter(pages),
+      [](decltype(article_map)::value_type const &kv) {
+          return kv.first;
+      });
 
  // init distance and predecessor
  std::map<std::string, int> distance;
@@ -158,4 +167,8 @@ std::vector<WikiGraph::RankedPage> WikiGraph::rankPages() const {
   std::vector<RankedPage> ranked_pages;
   // ...
   return ranked_pages;
+}
+
+bool WikiGraph::validStartAndEnd(const std::string& start_page, const std::string& end_page) const {
+  return (article_map.find(start_page) != article_map.end()) && (article_map.find(end_page) != article_map.end());
 }

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -97,3 +97,9 @@ TEST_CASE("BFS handles cycles", "BFS") {
   REQUIRE(expectedAE == w.getPathBFS("A", "E"));
   REQUIRE(expectedAD == w.getPathBFS("A", "D"));
 }
+
+TEST_CASE("BFS matches Dijkstra's given real data", "real") {
+  WikiGraph w("./datasets/links.tsv");
+
+  REQUIRE(w.getPathBFS("12th century", "Walrus") == w.getPathDijkstras("12th century", "Walrus"));
+}

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -50,6 +50,18 @@ TEST_CASE("Dijkstra's picks the best path", "dijkstras") {
   REQUIRE(expectedAD == w.getPathDijkstras("A", "D"));
 }
 
+TEST_CASE("Dijkstra's handles cycles", "BFS") {
+  std::vector<std::string> expectedAE = {
+    "A", "E"
+  };
+  std::vector<std::string> expectedAD = {
+    "A", "B", "D"
+  };
+  WikiGraph w("./datasets/cycle.tsv");
+  REQUIRE(expectedAE == w.getPathDijkstras("A", "E"));
+  REQUIRE(expectedAD == w.getPathDijkstras("A", "D"));
+}
+
 TEST_CASE("BFS simple", "BFS") {
   std::vector<std::string> expectedAE = {
     "A", "B", "C", "D", "E"
@@ -70,6 +82,18 @@ TEST_CASE("BFS picks the best path", "BFS") {
     "A", "B", "D"
   };
   WikiGraph w("./datasets/diff_paths.tsv");
+  REQUIRE(expectedAE == w.getPathBFS("A", "E"));
+  REQUIRE(expectedAD == w.getPathBFS("A", "D"));
+}
+
+TEST_CASE("BFS handles cycles", "BFS") {
+  std::vector<std::string> expectedAE = {
+    "A", "E"
+  };
+  std::vector<std::string> expectedAD = {
+    "A", "B", "D"
+  };
+  WikiGraph w("./datasets/cycle.tsv");
   REQUIRE(expectedAE == w.getPathBFS("A", "E"));
   REQUIRE(expectedAD == w.getPathBFS("A", "D"));
 }


### PR DESCRIPTION
noticed that "Avatar__The_Last_Airbender" and other pages have two underscores to represent ": ", so I fixed the decoder to reflect this.